### PR TITLE
change back to install profile rather than distribution

### DIFF
--- a/origins.info.yml
+++ b/origins.info.yml
@@ -2,8 +2,6 @@ name: NICS Origins
 type: profile
 description: To provide common functionality for various NICS websites
 core: 8.x
-distribution:
-  name: origins
 install:
   - node
   - history


### PR DESCRIPTION
This change is needed so that the Cyber Security site can be installed from config