### PR TITLE
configure NICS workflow

### DIFF
--- a/config/optional/workflows.workflow.nics_editorial_workflow.yml
+++ b/config/optional/workflows.workflow.nics_editorial_workflow.yml
@@ -1,0 +1,97 @@
+uuid: 126b4014-7d97-4ff5-9b86-1738ab9a5939
+langcode: en
+status: true
+dependencies:
+  module:
+    - content_moderation
+_core:
+  default_config_hash: Tk4jVzihIcXtxZREjwCMLydvSVPKzgW1Lph-NY45Ay8
+id: nics_editorial_workflow
+label: 'NICS Editorial Workflow'
+type: content_moderation
+type_settings:
+  states:
+    archived:
+      published: false
+      default_revision: true
+      label: Archived
+      weight: 3
+    draft:
+      label: Draft
+      published: false
+      default_revision: false
+      weight: 0
+    needs_review:
+      published: false
+      default_revision: false
+      label: 'Needs Review'
+      weight: 2
+    published:
+      label: Published
+      published: true
+      default_revision: true
+      weight: 1
+  transitions:
+    archive:
+      label: Archive
+      from:
+        - published
+      to: archived
+      weight: 3
+    create_new_draft:
+      label: 'Create New Draft'
+      to: draft
+      weight: -3
+      from:
+        - draft
+    draft_of_published:
+      label: 'Draft of Published'
+      from:
+        - published
+      to: draft
+      weight: 6
+    publish:
+      label: Publish
+      to: published
+      weight: 1
+      from:
+        - needs_review
+    quick_publish:
+      label: 'Quick Publish'
+      from:
+        - draft
+      to: published
+      weight: -1
+    reject:
+      label: Reject
+      from:
+        - needs_review
+      to: draft
+      weight: 0
+    restore:
+      label: Restore
+      from:
+        - archived
+      to: published
+      weight: 5
+    restore_to_draft:
+      label: 'Restore to Draft'
+      from:
+        - archived
+      to: draft
+      weight: 4
+    submit_for_review:
+      label: 'Submit for Review'
+      from:
+        - draft
+      to: needs_review
+      weight: -2
+    unpublish:
+      label: Unpublish
+      from:
+        - published
+      to: needs_review
+      weight: 2
+  entity_types:
+    node: null
+  default_moderation_state: draft


### PR DESCRIPTION
Now that the origins_workflow module is installed by default, we need to add config for the 'NICS Editorial' workflow into the optional config directory